### PR TITLE
Add scan_after functionality to zgrab

### DIFF
--- a/processing.go
+++ b/processing.go
@@ -14,6 +14,7 @@ import (
 type Grab struct {
 	IP     string                  `json:"ip,omitempty"`
 	Domain string                  `json:"domain,omitempty"`
+	ScanAfter string               `json:"scan_after,omitempty"`
 	Data   map[string]ScanResponse `json:"data,omitempty"`
 }
 
@@ -22,6 +23,7 @@ type ScanTarget struct {
 	IP     net.IP
 	Domain string
 	Tag    string
+	ScanAfter string
 	Port   *uint
 }
 
@@ -124,6 +126,7 @@ func BuildGrabFromInputResponse(t *ScanTarget, responses map[string]ScanResponse
 	return &Grab{
 		IP:     ipstr,
 		Domain: t.Domain,
+		ScanAfter: t.ScanAfter,
 		Data:   responses,
 	}
 }


### PR DESCRIPTION
Enables scan_after functionality in zgrab:
-  adds scan_after field to zgrab Input and modifies parsing to retrieve scan_after data passed in from sentinel orchestra
- adds checkScanAfter function used in consumer to sleep for designated amount of time before scanning.

To test, monitor the output from zgrab_4hr using `./cmd/zgrab2/zgrab2 multiple -c multiple.ini --nsq-mode --nsq-input-topic zgrab_4hr --nsq-output-topic zgrab_results`. The expected behavior for the first input received in zgrab_4hr is to sleep immediately for 14400 seconds.
