### PR TITLE
add cert_type to zgrab metadata

### DIFF
--- a/input.go
+++ b/input.go
@@ -89,7 +89,7 @@ func duplicateIP(ip net.IP) net.IP {
 type ZGrabMetadata struct {
 	ScanAfter string `json:"scan_after"`
 	CertSHA1  string `json:"cert_sha1"`
-	CertType  string `json:cert_type"`
+	CertType  string `json:"cert_type"`
 }
 
 type Input struct {


### PR DESCRIPTION
Simply adds cert_type to zgrabs metadata so that it appears in its output as well.