### PR TITLE
Realized the option of specifying the local address of sentinel-zgrab2

### DIFF
--- a/config.go
+++ b/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	ConnectionsPerHost int             `long:"connections-per-host" default:"1" description:"Number of times to connect to each host (results in more output)"`
 	ReadLimitPerHost   int             `long:"read-limit-per-host" default:"96" description:"Maximum total kilobytes to read for a single host (default 96kb)"`
 	Prometheus         string          `long:"prometheus" description:"Address to use for Prometheus server (e.g. localhost:8080). If empty, Prometheus is disabled."`
+	LocalAddrStr       string          `long:"local-addr" description:"Local source address for outgoing connections (e.g. 192.168.10.2:0, port is required even if it's 0)"`
 	Multiple           MultipleCommand `command:"multiple" description:"Multiple module actions"`
 	inputFile          *os.File
 	outputFile         *os.File
@@ -108,6 +109,15 @@ func validateFrameworkConfiguration() {
 		log.Fatalf("invalid GOMAXPROCS (must be positive, given %d)", config.GOMAXPROCS)
 	}
 	runtime.GOMAXPROCS(config.GOMAXPROCS)
+
+	// Parse and validate the local address if specified
+	if config.LocalAddrStr != "" {
+		var err error
+		config.localAddr, err = net.ResolveTCPAddr("tcp", config.LocalAddrStr)
+		if err != nil {
+			log.Fatalf("could not resolve local address %s: %v", config.LocalAddrStr, err)
+		}
+	}
 
 	//validate/start prometheus
 	if config.Prometheus != "" {

--- a/conn.go
+++ b/conn.go
@@ -236,11 +236,15 @@ func NewTimeoutConnection(ctx context.Context, conn net.Conn, timeout, readTimeo
 func DialTimeoutConnectionEx(proto string, target string, dialTimeout, sessionTimeout, readTimeout, writeTimeout time.Duration, bytesReadLimit int) (net.Conn, error) {
 	var conn net.Conn
 	var err error
-	if dialTimeout > 0 {
-		conn, err = net.DialTimeout(proto, target, dialTimeout)
-	} else {
-		conn, err = net.DialTimeout(proto, target, sessionTimeout)
+	dialer := &net.Dialer{
+		Timeout: dialTimeout,
 	}
+
+	if config.localAddr != nil {
+		dialer.LocalAddr = config.localAddr
+	}
+
+	conn, err = dialer.Dial(proto, target)
 	if err != nil {
 		if conn != nil {
 			conn.Close()
@@ -300,7 +304,9 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.
 	d.Dialer.KeepAlive = d.Timeout
 
 	// Copy over the source IP if set, or nil
-	d.Dialer.LocalAddr = config.localAddr
+	if config.localAddr != nil {
+		d.Dialer.LocalAddr = config.localAddr
+	}
 
 	dialContext, cancelDial := context.WithTimeout(ctx, d.Dialer.Timeout)
 	defer cancelDial()


### PR DESCRIPTION
Realized the option of specifying the local address of sentinel-zgrab2, which can be verified by tcpdump, example: 'echo "172.67.161.24, renovatepattaya.com" | ./zgrab2 --local-addr=128.192.12.101:0 tls'

## How to Test

(long:"local-addr" description:"Local source address for outgoing connections (e.g. 192.168.10.2:0, port is required even if it's 0)")

In terminal 1, run zgrab2:
'echo "172.67.161.24, renovatepattaya.com" | ./zgrab2 --local-addr=128.192.12.101:0 tls'

In terminal 2, run tcpdump to verify the local address:
sudo tcpdump -i any -nn port 443

## Notes & Caveats

In the previous version of sentinel-zgrab2, 'config.go' had the 'local-addr' option but could not be used. I fixed the 'local-addr' option which will be shown by 'zgrab -h'. Users can specify different local addresses, if any. 

## Issue Tracking

https://github.com/gakiwate/sentinel-zgrab2/issues/7
